### PR TITLE
Fix TypeError in Exception.

### DIFF
--- a/python/sts/sts.py
+++ b/python/sts/sts.py
@@ -145,7 +145,7 @@ class Sts:
         except Exception as e:
             result = "error"
             if result_json is not None:
-                result = result_json
+                result = str(result_json)
             raise Exception("result: " + result, e)
 
     def __encrypt(self, method, url, key_values):


### PR DESCRIPTION
Under Python 3.7:
```bash
line 150, in get_credential
    raise Exception("result: " + result, e)
TypeError: can only concatenate str (not "dict") to str
```

`result_json is not None` does not guarantee `result_json` is type of `str`.