### PR TITLE
修正README.md中maven依赖的版本

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -5,7 +5,7 @@
 <dependency>
     <groupId>com.qcloud</groupId>
     <artifactId>cos-sts_api</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
 </dependency>
 ```
 


### PR DESCRIPTION
3.1.0 -> 3.1.1