### PR TITLE
feat: 修复缺少的 TS 接口属性

### DIFF
--- a/nodejs/index.d.ts
+++ b/nodejs/index.d.ts
@@ -43,6 +43,9 @@ export interface CredentialData {
     /** 请求时需要用的 token 字符串，最终请求 COS API 时，需要放在 Header 的 x-cos-security-token 字段 */
     sessionToken: string;
   }
+
+    /** 请求 ID */
+    requestId: string;
 }
 
 /** 获取临时密钥接口(获取联合身份临时访问凭证)。 */


### PR DESCRIPTION
获取临时密钥的接口返回的数据里面包括一个叫 requestId 的字段：
![屏幕截图 2025-02-19 123532](https://github.com/user-attachments/assets/5106e41e-1d08-45a4-97db-38457f87cd2f)

但是定义这个返回数据的 TS 接口里面却没有定义它：
![屏幕截图 2025-02-19 123654](https://github.com/user-attachments/assets/b37eff69-0a05-4ca2-a580-cf4e631b8dfb)

所以我在 TS 接口里面补充了 requestId 属性。
![屏幕截图 2025-02-19 124231](https://github.com/user-attachments/assets/13d0e03f-4d4b-41dd-9cda-dd85f2976ed5)
